### PR TITLE
Bugfix/snackbar spacing

### DIFF
--- a/packages/regal/lib/src/widgets/snack_bar.dart
+++ b/packages/regal/lib/src/widgets/snack_bar.dart
@@ -101,25 +101,27 @@ class Snackbar extends StatelessWidget with EventTrackMixin {
     return null;
   }
 
-  Widget wrap(Widget widget, BuildContext context) => Column(
-        mainAxisAlignment: MainAxisAlignment.end,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          ClipRRect(
-            borderRadius: BorderRadius.circular(20.sp),
-            child: Material(
-              color: Colors.transparent,
-              child: DecoratedBox(
-                decoration: BoxDecoration(
-                  border: Border.all(color: context.grey.shade20),
-                  borderRadius: BorderRadius.circular(20.sp),
+  Widget wrap(Widget widget, BuildContext context) => SafeArea(
+        minimum: Spacing.huge.y,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.end,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ClipRRect(
+              borderRadius: BorderRadius.circular(20.sp),
+              child: Material(
+                color: Colors.transparent,
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    border: Border.all(color: context.grey.shade20),
+                    borderRadius: BorderRadius.circular(20.sp),
+                  ),
+                  child: widget,
                 ),
-                child: widget,
               ),
             ),
-          ),
-          const RegalBottomSpacer(),
-        ],
+          ],
+        ),
       );
 
   @override


### PR DESCRIPTION

https://github.com/ATOAPaymentsLimited/atoa-flutter-packages/assets/55907631/f78d4971-53e8-4c45-a483-199ff517232c



- `RegalBottomSpacer` uses max of bottom or 34.sp. This won't work for the scenario when keyboard is opened and snackbar is being displayed. Added the `minimum` property to `SafeArea` for handling this use case and removed `RegalBottomSpacer` (verified on Android and iOS).