### PR TITLE
feature: regal singleton

### DIFF
--- a/packages/regal/lib/src/mixin/event_track_mixin.dart
+++ b/packages/regal/lib/src/mixin/event_track_mixin.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:regal/src/callbacks/callbacks.dart';
+import 'package:regal/regal.dart';
 
 mixin EventTrackMixin<T extends Widget> {
   void logClickEvent(
@@ -8,7 +8,7 @@ mixin EventTrackMixin<T extends Widget> {
     Map<String, dynamic>? trackProperties,
     required bool enableTracking,
   }) {
-    if (!enableTracking) {
+    if (!(enableTracking || Regal.enableTracking)) {
       return;
     }
     try {

--- a/packages/regal/lib/src/utils/regal.dart
+++ b/packages/regal/lib/src/utils/regal.dart
@@ -1,0 +1,8 @@
+class Regal {
+  factory Regal() => _instance;
+  Regal._();
+
+  static final _instance = Regal._();
+
+  static bool enableTracking = true;
+}

--- a/packages/regal/lib/src/utils/utils.dart
+++ b/packages/regal/lib/src/utils/utils.dart
@@ -1,3 +1,4 @@
+export 'regal.dart';
 export 'snackbar_extension.dart';
 export 'spacing.dart';
 export 'text_style_extension.dart';


### PR DESCRIPTION
It's inconvenient to disable or enable tracking for all the widgets explicitly.
This singleton makes the job easy. Especially when clickables are inside atoa-packages.